### PR TITLE
Use `dualize` in Tensorial, not ForwardDiff

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Femto"
 uuid = "8a6dffb5-f0a3-43b0-807d-ee99672b66b8"
 authors = ["Keita Nakamura <keita.nakamura.1109@gmail.com>"]
-version = "0.11.5"
+version = "0.11.6"
 
 [deps]
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"

--- a/src/Elements/common.jl
+++ b/src/Elements/common.jl
@@ -130,8 +130,8 @@ end
 
 # special version for AD
 function integrate!(f, F::AbstractVector, K::AbstractMatrix, field::Field, element::BodyElementLike, U::SVector)
-    T = typeof(ForwardDiff.Tag(interpolate, eltype(U)))
-    dU = ForwardDiff.dualize(T, U)
+    Tg = ForwardDiff.Tag(interpolate, eltype(U))
+    dU = SArray(Tensorial.dualize(Tg, Tensor(U)))
     for qp in 1:num_quadpoints(element)
         du = interpolate(field, element, dU, qp)
         @inbounds integrate!(f, F, K, field, element, du, qp)


### PR DESCRIPTION
`dualize` is gone and new interface returns MVector instead SVector in ForwardDiff.